### PR TITLE
Fix 3 bugs in edit favourites modal 

### DIFF
--- a/assets/js/recipeSearch.js
+++ b/assets/js/recipeSearch.js
@@ -403,6 +403,9 @@ function renderFavourites() {
   if (!uris) {
     // Empty the results
     $("#recipe-results").empty();
+
+    // Render the favourite recipes modal to prevent a single recipe being left over once the favourite array is empty
+    renderFavouritesModal();
     return false;
   }
 

--- a/assets/js/recipeSearch.js
+++ b/assets/js/recipeSearch.js
@@ -337,6 +337,9 @@ $("#deleteAllFavourites").on("click", function () {
 
   // Empty the results
   $("#recipe-results").empty();
+
+  // Render the edit favourites modal so it is emptied too
+  renderFavouritesModal();
 });
 
 // Event listener for the favourites modal to update its contents before being displayed

--- a/assets/js/recipeSearch.js
+++ b/assets/js/recipeSearch.js
@@ -185,7 +185,7 @@ $("#searchRecipes").on("click", function () {
 
   if (mealChoice) {
     meal = [mealChoice.toLowerCase()];
-  } 
+  }
 
   let dietChoice = $("input[name='dietary-req']:checked").attr("id");
 
@@ -221,11 +221,11 @@ $("#searchRecipes").on("click", function () {
   let usersAllergies = allergiesArray.filter((element) => allergieChoices.includes(element));
 
   // create new array to display in lower case later
-  let usersAllergiesInLower = []
+  let usersAllergiesInLower = [];
 
   for (let i = 0; i < usersAllergies.length; i++) {
     allergy = usersAllergies[i].toLowerCase();
-    usersAllergiesInLower.push(allergy)
+    usersAllergiesInLower.push(allergy);
   }
 
   // console.log(usersDiet);
@@ -431,7 +431,9 @@ function renderFavourites() {
       // Handle any errors
       console.error("Error:", data.error);
     } else {
+      //Render recipes in results and the edit favourites modal list
       renderRecipes(data);
+      renderFavouritesModal();
     }
   });
 }
@@ -876,8 +878,6 @@ $("#favouriteRecipesEditModal").on("click", ".recipe-favourite", function (e) {
   const uri = $(this).attr("data-uri");
 
   removeFavouriteRecipe(uri);
-
-  renderFavouritesModal();
 
   renderFavourites();
 });


### PR DESCRIPTION
Hi Jenny,

This PR squashes the following 3 bugs in the edit favourites modal:

1. Clicking the heart icon to unfavourite a single recipe when viewing the favourites page doesn't remove that recipe from the edit modal.
2. Clicking the Delete All button then reopening the modal doesn't show an empty modal.
3. When removing recipes one by one in the modal, the last one is stuck.
