### PR TITLE
prevent searching for recipes with 'undefined' tags

### DIFF
--- a/assets/js/recipeSearch.js
+++ b/assets/js/recipeSearch.js
@@ -176,9 +176,13 @@ $("#searchRecipes").on("click", function () {
 
   // converts into an array of query tags
   let tagsArray = tags.split("+");
-  let qTags;
+  let qTags = "";
   for (let i = 0; i < tagsArray.length; i++) {
-    qTags = qTags + "&tag=" + tagsArray[i];
+    if (i === 0) {
+      qTags = tagsArray[i];
+    } else {
+      qTags = qTags + "&tag=" + tagsArray[i];
+    }
   }
 
   let mealChoice = $("input[name='meal-type']:checked").attr("id");


### PR DESCRIPTION
Hi Jenny, the recipe search query is being built with the first tag=undefined so unwanted recipes are appearing in results.

To test this PR, console log recipeSearchURL (around line 279 in recipeSearch.js):

```
let recipeSearchURL = `https://api.edamam.com/api/recipes/v2?type=public&app_id=${RECIPE_SEARCH_API_ID}&app_key=${RECIPE_SEARCH_API_KEY}&random=${random}&tag=${qTags}`;

console.log(recipeSearchURL);
```
This issue is fixed by testing the first tag query parameter when looping tagsArray so the string doesn't start undefined.